### PR TITLE
temporarily disable strongest optimisation in methods.py

### DIFF
--- a/parser/methods.py
+++ b/parser/methods.py
@@ -253,7 +253,7 @@ def parse_tuples(elt, symbolic, domains=None):
                 return [parse_integer_or_interval(tok) for tok in tokens], False, False
             return [value for tok in tokens if (value := int(tok),) and (domains is None or value in domains[0])], False, domains is not None
     starred = ("*" in s)
-    if symbolic or (domains is not None) or starred:
+    if True: #symbolic or (domains is not None) or starred:
         # original code, some tweaks
         func = parse_symbolic_tuple if symbolic else parse_ordinary_tuple  # reference to function
         tokens = re_lists.split(s[1:-1])  # cut first and last '(', ')'
@@ -262,10 +262,10 @@ def parse_tuples(elt, symbolic, domains=None):
             t, tok_is_star = func(tok, domains)
             if t is not None:  # if not filtered-out parsed tuple
                 m.append(t)
-    else:
-        # optimized code for non-symbolic, non-star, non-domains case with NumPy
-        csv_string = s[1:-1].replace(')(','\n')  # convert to CSV
-        array = loadtxt(StringIO(csv_string), delimiter=',', dtype=int)
-        m = array.tolist()  # this part is the most time consuming
+    #else: DISABLED till tested more thoroughly (e.g. instancesXCSP22/MiniCOP/Fapp-ext-01-0200_c18.xml)
+    #    # optimized code for non-symbolic, non-star, non-domains case with NumPy
+    #    csv_string = s[1:-1].replace(')(','\n')  # convert to CSV
+    #    array = loadtxt(StringIO(csv_string), delimiter=',', dtype=int)
+    #    m = array.tolist()  # this part is the most time consuming
 
     return m, starred, domains is not None


### PR DESCRIPTION
Hi again, in follow up to the merged #46 

Do you have a way to test that the parser still works correctly on all instances?

I was not able to test it very thoroughly unfortunately, and I notice that on 'instancesXCSP22/MiniCOP/Fapp-ext-01-0200_c18.xml' it does something that makes CPMpy crash later on in the process.

So, until there is a way (or we have capacity to) test the changed parser on all instances, the 'numpy' optimisation is best disabled (done so in this pull request).

The other minor optimisations now merged do help a bit...