### PR TITLE
Add __repr__ and __str__ methods for ECtr

### DIFF
--- a/pycsp3/classes/entities.py
+++ b/pycsp3/classes/entities.py
@@ -136,6 +136,12 @@ class ECtr(Entity):
                 + "\n\tSee also the end of section about constraint Intension in chapter 'Twenty popular constraints' of the guide.\n")
         return True
 
+    def __repr__(self) -> str:
+        return str(self.constraint)
+
+    def __str__(self) -> str:
+        return str(self.constraint)
+
     def to_table(self):  # experimental
         c = self.constraint
         if c.name == TypeCtr.ALL_DIFFERENT and c.arguments[TypeCtrArg.LIST].lifted and TypeCtrArg.EXCEPT not in c.arguments:


### PR DESCRIPTION
Right now lists of constraints print as `<ECtr object at ...>`. Adding `ECtr.__repr__` (same as `__str__`) makes diagnostics readable, which helps debugging UNSAT models and tools like [pycsp3-explain](https://github.com/sohaibafifi/pycsp3-explain) that return `ECtr` lists.