### PR TITLE
Add a runnable example to each public function, and fix Not()

### DIFF
--- a/pycsp3/__init__.py
+++ b/pycsp3/__init__.py
@@ -55,10 +55,21 @@ CHOCO = TypeSolver.CHOCO
 """ Solver Choco """
 
 Task = namedtuple("Task", ("origin", "length", "height"), defaults=(None,))
-""" A task, as involved in the constraint Cumulative: its origin (starting time), its length (duration) and its height (amount of consumed resource) """
+""" A task, as involved in the constraint Cumulative: its origin (starting time), its length (duration) and its height (amount of consumed resource)
+
+:example:
+    s = VarArray(size=3, dom=range(10))
+    satisfy(Cumulative(Task(origin=s[i], length=2, height=1) for i in range(3)) <= 2)
+"""
 
 Item = namedtuple("Item", ("bin", "size"))
-""" An item, as involved in bin-packing problems: the bin it is put in, and its size """
+""" An item, as involved in bin-packing problems: the bin it is put in, and its size
+
+:example:
+    b = VarArray(size=3, dom=range(2))
+    items = [Item(bin=b[i], size=i + 1) for i in range(3)]
+    print(items[0].size)
+"""
 
 if sys.argv:
     from pycsp3.compiler import Compilation
@@ -112,6 +123,11 @@ def solver(name=None):
 
     :param name: the name of the solver to be built, or None (by default)
     :return: either the current solver if the specified name is None, or a newly created solver whose name is specified
+    :example:
+        x = VarArray(size=3, dom=range(3))
+        satisfy(AllDifferent(x))
+        solve(solver=ACE)
+        print(solver())
     """
     return _solver if name is None else _set_solver(name)
 
@@ -123,6 +139,11 @@ def compile(filename=None, *, verbose=0):
     :param filename: the filename of the compiled problem instance
     :param verbose: verbosity level from -1 to 2
     :return: a pair composed of a string (filename) and a Boolean (True if a COP, False otherwise)
+    :example:
+        x = VarArray(size=3, dom=range(3))
+        satisfy(AllDifferent(x))
+        filename, cop = compile()
+        print(filename, cop)
     """
     from pycsp3.compiler import Compilation
     filename, cop = Compilation.compile(filename, verbose=verbose)
@@ -132,6 +153,11 @@ def compile(filename=None, *, verbose=0):
 def status():
     """
     Returns the status of the last solving operation, or None
+    :example:
+        x = VarArray(size=3, dom=range(3))
+        satisfy(AllDifferent(x))
+        solve()
+        print(status())
     """
     return None if _solver is None else _solver.status
 
@@ -139,6 +165,11 @@ def status():
 def solution():
     """
     Returns a complex object corresponding to the last found solution, or None
+    :example:
+        x = VarArray(size=3, dom=range(3))
+        satisfy(AllDifferent(x))
+        if solve() is SAT:
+            print(solution())
     """
     return None if _solver is None else _solver.last_solution
 
@@ -146,6 +177,11 @@ def solution():
 def n_solutions():
     """
     Returns the number of solutions found by the last solving operation, or None
+    :example:
+        x = VarArray(size=3, dom=range(3))
+        satisfy(AllDifferent(x))
+        solve(sols=ALL)
+        print(n_solutions())
     """
     return None if _solver is None else _solver.n_solutions
 
@@ -153,6 +189,12 @@ def n_solutions():
 def bound():
     """
     Returns the bound found by the last solving operation, or None
+    :example:
+        x = VarArray(size=3, dom=range(3))
+        satisfy(AllDifferent(x))
+        minimize(Sum(x))
+        if solve() is OPTIMUM:
+            print(bound())
     """
     return None if _solver is None else _solver.bound
 
@@ -160,6 +202,11 @@ def bound():
 def core():
     """
     Returns the core identified by the last extraction operation, or None
+    :example:
+        x = VarArray(size=2, dom=range(2))
+        satisfy(x[0] == 0, x[0] == 1)
+        if solve(extraction=True) is CORE:
+            print(core())
     """
     return None if _solver is None else _solver.core
 
@@ -184,6 +231,11 @@ def solve(*, solver=ACE, options="", filename=None, verbose=-1, sols=None, extra
     :param sols: number of solutions to be found (ALL if no limit)
     :param extraction: True if an unsatisfiable core of constraints must be sought
     :return: the status of the solving operation
+    :example:
+        x = VarArray(size=3, dom=range(3))
+        satisfy(AllDifferent(x))
+        if solve() is SAT:
+            print(values(x))
     """
     global _solver
     instance = compile(filename, verbose=verbose)

--- a/pycsp3/classes/auxiliary/conditions.py
+++ b/pycsp3/classes/auxiliary/conditions.py
@@ -278,6 +278,10 @@ def lt(v):
 
     :param v: either an integer or the root node of an expression
     :return: an object Condition
+    :example:
+        x = Var(range(10))
+        b = VarArray(size=2, dom={0, 1})
+        satisfy(Match(x, Cases={lt(5): b[0] == 1, ge(5): b[1] == 1}))
     """
     return _build_condition(LT, v)
 
@@ -289,6 +293,10 @@ def le(v):
 
     :param v: either an integer or the root node of an expression
     :return: an object Condition
+    :example:
+        x = Var(range(10))
+        b = VarArray(size=2, dom={0, 1})
+        satisfy(Match(x, Cases={le(4): b[0] == 1, gt(4): b[1] == 1}))
     """
     return _build_condition(LE, v)
 
@@ -300,6 +308,10 @@ def ge(v):
 
     :param v: either an integer or the root node of an expression
     :return: an object Condition
+    :example:
+        x = Var(range(10))
+        b = VarArray(size=2, dom={0, 1})
+        satisfy(Match(x, Cases={ge(5): b[0] == 1, lt(5): b[1] == 1}))
     """
     return _build_condition(GE, v)
 
@@ -311,6 +323,10 @@ def gt(v):
 
     :param v: either an integer or the root node of an expression
     :return: an object Condition
+    :example:
+        x = Var(range(10))
+        b = VarArray(size=2, dom={0, 1})
+        satisfy(Match(x, Cases={gt(4): b[0] == 1, le(4): b[1] == 1}))
     """
     return _build_condition(GT, v)
 
@@ -322,6 +338,10 @@ def eq(v):
 
     :param v: either an integer or the root node of an expression
     :return: an object Condition
+    :example:
+        x = Var(range(10))
+        b = VarArray(size=2, dom={0, 1})
+        satisfy(Match(x, Cases={eq(0): b[0] == 1, ne(0): b[1] == 1}))
     """
     return _build_condition(EQ, v)
 
@@ -333,6 +353,10 @@ def ne(v):
 
     :param v: either an integer or the root node of an expression
     :return: an object Condition
+    :example:
+        x = Var(range(10))
+        b = VarArray(size=2, dom={0, 1})
+        satisfy(Match(x, Cases={ne(0): b[0] == 1, eq(0): b[1] == 1}))
     """
     return _build_condition(NE, v)
 
@@ -365,5 +389,8 @@ def complement(*v):
 
     :param v: a range, a set, a tuple or a list of integers
     :return: an object Condition
+    :example:
+        b = VarArray(size=4, dom={0, 1})
+        satisfy(Knapsack(b, weights=[3, 2, 2, 1], wcondition=complement(range(3)), profits=[4, 3, 2, 1]) >= 6)
     """
     return _inside_outside(NOTIN, v)

--- a/pycsp3/classes/auxiliary/diagrams.py
+++ b/pycsp3/classes/auxiliary/diagrams.py
@@ -106,6 +106,10 @@ class Automaton(Diagram):
         :param start: the starting state
         :param transitions: a set of transitions
         :param final: the final state(s)
+        :example:
+            x = VarArray(size=4, dom=range(2))
+            a = Automaton(start="q0", final="q1", transitions=[("q0", 0, "q0"), ("q0", 1, "q1"), ("q1", 1, "q1")])
+            satisfy(Regular(scope=x, automaton=a))
         """
         super().__init__(transitions)
         self.start = start
@@ -184,6 +188,10 @@ class MDD(Diagram):
         Builds an MDD from the specified set of transitions
 
         :param transitions: a set of transitions
+        :example:
+            x = VarArray(size=3, dom=range(2))
+            m = MDD([("r", 0, "n1"), ("r", 1, "n2"), ("n1", 1, "t"), ("n2", 0, "t")])
+            satisfy(x in m)
         """
         if isinstance(transitions, types.GeneratorType):
             transitions = [t for t in transitions]

--- a/pycsp3/classes/auxiliary/tables.py
+++ b/pycsp3/classes/auxiliary/tables.py
@@ -38,6 +38,10 @@ def to_ordinary_table(table, domains, *, possibly_starred=False):
     :param domains: the domains of integers to be considered for each column of the table
     :param possibly_starred: if True, the returned table may be starred (and not purely ordinary)
     :return: an ordinary or starred table
+    :example:
+        T = to_ordinary_table({(0, ANY), (1, 1)}, [2, 2])
+        x = VarArray(size=2, dom=range(2))
+        satisfy((x[0], x[1]) in T)
     """
 
     def _tuple_of_interest(t):

--- a/pycsp3/classes/entities.py
+++ b/pycsp3/classes/entities.py
@@ -350,6 +350,12 @@ class AnnEntities:
 def clear():
     """
     Removes everything that was declared (variables) or posted (constraints, objective)
+    :example:
+        x = VarArray(size=3, dom=range(3))
+        satisfy(AllDifferent(x))
+        clear()
+        y = VarArray(size=2, dom=range(2))
+        satisfy(y[0] != y[1])
     """
     VarEntities.items = []
     VarEntities.varToEVar = dict()

--- a/pycsp3/compiler.py
+++ b/pycsp3/compiler.py
@@ -241,6 +241,11 @@ def load_json_data(filename, *, storing=False, record_string_data=True):
 
     :param filename: name (possibly a URL) of a JSON file
     :return: the loaded data
+    :example:
+        open("instance.json", "w").write('{"n": 4, "k": 2}')
+        data = load_json_data("instance.json")
+        x = VarArray(size=data.n, dom=range(data.k))
+        satisfy(AllDifferent(x))
     """
     assert filename.endswith(".json")
     if filename.startswith("http"):
@@ -289,6 +294,11 @@ def default_data(filename):
 
     :param filename: name (possibly a URL) of a JSON file
     :return: the loaded data
+    :example:
+        open("defaults.json", "w").write('{"n": 4, "k": 2}')
+        data = default_data("defaults.json")
+        x = VarArray(size=data.n, dom=range(data.k))
+        satisfy(AllDifferent(x))
     """
     return load_json_data(filename, storing=True)
 

--- a/pycsp3/compiler.py
+++ b/pycsp3/compiler.py
@@ -239,7 +239,7 @@ def load_json_data(filename, *, storing=False, record_string_data=True):
     """
     Loads and returns the data from the specified JSON file (possibly given by a URL)
 
-    :param filename: name (possibly ULR) of a JSON file
+    :param filename: name (possibly a URL) of a JSON file
     :return: the loaded data
     """
     assert filename.endswith(".json")
@@ -287,7 +287,7 @@ def default_data(filename):
     """
     Loads data from the specified JSON file (possibly given by a URL)
 
-    :param filename: mane (possibly ULR) of a JSON file
+    :param filename: name (possibly a URL) of a JSON file
     :return: the loaded data
     """
     return load_json_data(filename, storing=True)

--- a/pycsp3/functions.py
+++ b/pycsp3/functions.py
@@ -885,6 +885,17 @@ def _Intension(node):
 
 
 def col(*args):
+    """
+    Builds and returns a node denoting the ith column of a hybrid tuple.
+
+    Hybrid (smart) tables accept, besides plain values, expressions of the form
+    op(col(i)) where op is a relational operator among eq, ne, lt, le, gt and ge,
+    and col(i) refers to the value of the tuple at index i. An offset can be
+    added, as in eq(col(i) + 1).
+
+    :param args: the index of the column
+    :return: a node denoting the specified column of a hybrid tuple
+    """
     assert len(args) == 1 and isinstance(args[0], int)
     return Node(TypeNode.COL, args[0])
 

--- a/pycsp3/functions.py
+++ b/pycsp3/functions.py
@@ -461,13 +461,16 @@ def Not(arg, meta=False):
     :param arg: a constraint
     :param meta: true if a meta-constraint form must be really posted
     :return: a meta-constraint Not, or its reified form
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(Not(AllDifferent(x)))
     """
     if options.use_meta or meta:
         return ENot(_wrap_intension_constraints(_complete_partial_forms_of_constraints(arg)))
     res = manage_global_indirection(arg)
     if res is None:
         return ENot(_wrap_intension_constraints(_complete_partial_forms_of_constraints(arg)))
-    return ~res  # TODO to be checked
+    return ~res[0] if len(res) == 1 else ~conjunction(*res)
 
 
 def Xor(*args, meta=False):

--- a/pycsp3/functions.py
+++ b/pycsp3/functions.py
@@ -49,6 +49,10 @@ def protect():
         protect().execute(...)
 
     :return: the object OpOverrider
+    :example:
+        x = VarArray(size=3, dom=range(3))
+        satisfy(AllDifferent(x))
+        print(protect().execute(x[0] == x[1]))
     """
     return OpOverrider.disable()
 
@@ -65,6 +69,12 @@ def variant(name=None):
 
     :param name: the name of a variant, or None
     :return: the name of the variant specified by the user, or a Boolean
+    :example:
+        x = VarArray(size=3, dom=range(3))
+        if variant("table"):
+            satisfy(Table(x, {(0, 1, 2)}))
+        else:
+            satisfy(AllDifferent(x))
     """
     assert options.variant is None or isinstance(options.variant, str)
     pos = -1 if options.variant is None else options.variant.find("-")  # position of dash in options.variant
@@ -81,6 +91,12 @@ def subvariant(name=None):
 
     :param name: the name of a sub-variant, or None
     :return: the name of the sub-variant specified by the user, or a Boolean
+    :example:
+        x = VarArray(size=3, dom=range(3))
+        if subvariant("short"):
+            satisfy(x[0] < x[1])
+        else:
+            satisfy(AllDifferent(x))
     """
     assert options.variant is None or isinstance(options.variant, str)
     pos = -1 if options.variant is None else options.variant.find("-")  # position of dash in options.variant
@@ -110,6 +126,10 @@ def Var(term=None, *others, dom=None, id=None):
     :param dom: the domain of the variable, or None
     :param id: the id (name) of the variable, or None (usually, None)
     :return: a stand-alone Variable with the specified domain
+    :example:
+        x = Var(range(10))
+        y = Var(0, 2, 4)
+        satisfy(x < y)
     """
     global started_modeling
     if not started_modeling and not options.uncurse:
@@ -173,6 +193,10 @@ def VarArray(doms=None, *, size=None, dom=None, dom_border=None, id=None, commen
     :param comment: a string
     :param tags: a (possibly empty) list of tags
     :return: an array of variables
+    :example:
+        x = VarArray(size=5, dom=range(10))
+        y = VarArray(size=[2, 3], dom={0, 1})
+        satisfy(AllDifferent(x))
     """
     global started_modeling
     if not started_modeling and not options.uncurse:
@@ -268,6 +292,9 @@ def VarArrayMultiple(*, size, fields):
     :param size: the size (an integer) or the dimensions (a list of integers) of the array
     :param fields: a dictionary mapping the name of each field to the domain of the corresponding variables
     :return: an array of named tuples of variables
+    :example:
+        t = VarArrayMultiple(size=3, fields={"start": range(10), "duration": range(1, 4)})
+        satisfy(Increasing(t.start))
     """
     assert isinstance(fields, dict) and all(isinstance(k, str) for k in fields)
     size = [size] if isinstance(size, int) else size
@@ -297,6 +324,10 @@ def var(name):
     """
     Returns the variable or variable array whose name is specified
     :param name: the name of the variable or variable array to be returned
+    :example:
+        x = VarArray(size=3, dom=range(3))
+        satisfy(AllDifferent(x))
+        print(var("x[0]"))
     """
     assert isinstance(name, str)
     error_if(name not in Variable.name2obj,
@@ -390,6 +421,9 @@ def And(*args, meta=False):
     :param args: a tuple of constraints
     :param meta: true if a meta-constraint form must be really posted
     :return: a meta-constraint And, or its reified form
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(And(Sum(x) > 4, AllDifferent(x)))
     """
     if options.use_meta or meta:
         return EAnd(_wrap_intension_constraints(_complete_partial_forms_of_constraints(flatten(*args))))
@@ -407,6 +441,9 @@ def Or(*args, meta=False):
     :param args: a tuple of constraints
     :param meta: true if a meta-constraint form must be really posted
     :return: a meta-constraint Or, or its reified form
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(Or(Sum(x) > 4, AllDifferent(x)))
     """
     if options.use_meta or meta:
         return EOr(_wrap_intension_constraints(_complete_partial_forms_of_constraints(flatten(*args))))
@@ -444,6 +481,9 @@ def Xor(*args, meta=False):
     :param args: a tuple of constraints
     :param meta: true if a meta-constraint form must be really posted
     :return: a meta-constraint Xor, or its reified form
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(Xor(Sum(x) > 4, AllDifferent(x)))
     """
     if options.use_meta or meta:
         return EXor(_wrap_intension_constraints(_complete_partial_forms_of_constraints(flatten(*args))))
@@ -501,6 +541,9 @@ def If(test, *test_complement, Then, Else=None, meta=False):
     :param Else: the Else part
     :param meta: true if a meta-constraint form must be really posted
     :return: a complex form of constraint(s) based on the control structure 'if then else'
+    :example:
+        x = VarArray(size=3, dom=range(3))
+        satisfy(If(x[0] > 0, Then=AllDifferent(x)))
     """
 
     # if len(testOthers) == 0 and isinstance(test, bool):  # We don't allow that because otherwise 'in' no more usable as in If(x[0] in (2,3), Then=...
@@ -588,6 +631,10 @@ def Match(Expr, *, Cases):
     :param Expr: the expression (a variable, a tuple of variables, or a constant term) subject to the case analysis
     :param Cases: a dictionary mapping values, tuples of values, sets, ranges or conditions to constraints
     :return: the list of constraints corresponding to the case analysis
+    :example:
+        x = Var(range(3))
+        y = VarArray(size=3, dom=range(2))
+        satisfy(Match(x, Cases={0: y[0] == 1, 1: y[1] == 1, 2: y[2] == 1}))
     """
     assert isinstance(Cases, dict)
     if isinstance(Expr, (tuple, list)):
@@ -624,6 +671,9 @@ def Iff(*args, meta=False):
     :param args: a tuple of constraints
     :param meta: true if a meta-constraint form must be really posted
     :return: a meta-constraint Iff, or its reified form
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(Iff(Sum(x) > 4, AllDifferent(x)))
     """
     if meta:
         return EIff(_wrap_intension_constraints(_complete_partial_forms_of_constraints(flatten(*args))))
@@ -640,6 +690,9 @@ def Slide(*args, expression=None, circular=None, offset=None, collect=None):
 
     :param args: a tuple of constraints
     :return: a meta-constraint Slide
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(Slide(x[i] < x[i + 1] for i in range(3)))
     """
     if expression is not None:  # the meta-constraint is defined directly by the user
         return ECtr(ConstraintSlide(*args, expression, circular, offset, collect))
@@ -715,6 +768,9 @@ def satisfy(*args, no_comment_tags_extraction=False):
 
     :param args: the different constraints to be posted
     :return: an object wrapping the posted constraints
+    :example:
+        x = VarArray(size=3, dom=range(3))
+        satisfy(AllDifferent(x), x[0] < x[1])
     """
 
     def _reorder(l):  # if constraints are given in (sub-)lists inside tuples; we flatten and reorder them to hopefully improve compactness
@@ -864,6 +920,9 @@ def Table(*, scope, supports=None, conflicts=None):
     :param conflicts: the set/list of tuples, seen as conflicts (negative table)
 
     :return: a constraint Table (Extension)
+    :example:
+        x = VarArray(size=3, dom=range(3))
+        satisfy((x[0], x[1], x[2]) in {(0, 1, 2), (1, 2, 0)})
     """
     scope = flatten(scope)
     assert scope is not None and (supports is None) != (conflicts is None)
@@ -895,6 +954,9 @@ def col(*args):
 
     :param args: the index of the column
     :return: a node denoting the specified column of a hybrid tuple
+    :example:
+        x = VarArray(size=3, dom=range(3))
+        satisfy((x[0], x[1], x[2]) in {(0, 1, 2), (1, eq(col(0)), 2)})
     """
     assert len(args) == 1 and isinstance(args[0], int)
     return Node(TypeNode.COL, args[0])
@@ -907,6 +969,9 @@ def abs(arg):
     Otherwise, the function returns, as usual, the absolute value of the specified argument
 
     :return: either a node, root of a tree expression, or the absolute value of the specified argument
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(abs(x[0] - x[1]) > 1)
     """
     if isinstance(arg, PartialConstraint):
         arg = auxiliary().replace_partial_constraint(arg)
@@ -922,6 +987,9 @@ def min(*args):
     Otherwise, the function returns, as usual, the smallest item of the specified arguments
 
     :return: either a node, root of a tree expression, or the smallest item of the specified arguments
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(min(x[0], x[1]) == 0)
     """
     if len(args) == 1 and isinstance(args[0], (tuple, list, set, frozenset)):
         args = [v for v in args[0]]
@@ -936,6 +1004,9 @@ def max(*args):
     Otherwise, the function returns, as usual, the largest item of the specified arguments
 
     :return: either a node, root of a tree expression, or the largest item of the specified arguments
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(max(x[0], x[1]) == 3)
     """
     if len(args) == 1 and isinstance(args[0], (tuple, list, set, frozenset)):
         args = [v for v in args[0]]
@@ -950,6 +1021,9 @@ def xor(*args):
     Without any parent, it becomes a constraint.
 
     :return: a node, root of a tree expression or the argument if there is only one
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(xor(x[0] == 0, x[1] == 1))
     """
     if len(args) == 1 and isinstance(args[0], (tuple, list, set, frozenset, types.GeneratorType)):
         args = tuple(args[0])
@@ -963,6 +1037,9 @@ def iff(*args):
     Without any parent, it becomes a constraint.
 
     :return: a node, root of a tree expression
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(iff(x[0] == 0, x[1] == 1))
     """
     if len(args) == 1 and isinstance(args[0], (tuple, list, set, frozenset, types.GeneratorType)):
         args = tuple(args[0])
@@ -981,6 +1058,9 @@ def imply(*args):
 
     :param args: a tuple of two arguments
     :return: a node, root of a tree expression
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(imply(x[0] == 0, x[1] == 1))
     """
     assert len(args) == 2
     cnd, tp = args  # condition and then part
@@ -1009,6 +1089,9 @@ def ift(test, Then, Else):
     :param Else: the Else part
 
     :return: a node, root of a tree expression
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(ift(x[0] == 0, x[1], x[2]) == 2)
     """
     # assert len(args) == 3
     # test, Then, Else = args  # condition, then part and else part
@@ -1063,6 +1146,9 @@ def belong(x, values):
     :param x: a variable, or an integer
     :param values: a set of integers (possibly given by a range), or a list of variables
     :return: a Boolean expression that holds iff the term belongs to the values
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(belong(x[0], {0, 2}))
     """
     if isinstance(x, PartialConstraint):
         x = auxiliary().replace_partial_constraint(x)
@@ -1093,6 +1179,9 @@ def not_belong(x, values):
     :param x: a variable, or an integer
     :param values: a set of integers (possibly given by a range), or a list of variables
     :return: a Boolean expression that holds iff the term does not belong to the values
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(not_belong(x[0], {0, 2}))
     """
     if isinstance(x, PartialConstraint):
         x = auxiliary().replace_partial_constraint(x)
@@ -1122,6 +1211,9 @@ def expr(operator, *args):
 
     :param operator: a string, or a constant from TypeNode or a constant from TypeConditionOperator or TypeOrderedOperator
     :return: a node, root of a tree expression
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(expr("lt", x[0], x[1]))
     """
     return Node.build(operator, *args)
 
@@ -1132,6 +1224,9 @@ def conjunction(*args):
     Without any parent, it becomes a constraint.
 
     :return: a node, root of a tree expression
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(conjunction(x[i] == i for i in range(3)))
     """
 
     # return Count(manage_global_indirection(*args)) == len(args)
@@ -1153,6 +1248,9 @@ def both(this, And):
     Without any parent, it becomes a constraint.
 
     :return: a node, root of a tree expression
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(both(x[0] == 0, x[1] == 1))
     """
     if this is None:
         return And
@@ -1173,6 +1271,9 @@ def disjunction(*args):
     Without any parent, it becomes a constraint.
 
     :return: a node, root of a tree expression
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(disjunction(x[i] == 0 for i in range(3)))
     """
     if len(args) == 1 and isinstance(args[0], (tuple, list, set, frozenset, types.GeneratorType)):
         args = tuple(args[0])
@@ -1188,6 +1289,9 @@ def either(this, Or):
     Without any parent, it becomes a constraint.
 
     :return: a node, root of a tree expression
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(either(x[0] == 0, x[1] == 1))
     """
     if this is None:
         return Or
@@ -1213,6 +1317,10 @@ def Regular(*, scope, automaton):
     :param automaton: the automaton defining the semantics of the constraint
 
     :return: a constraint Regular
+    :example:
+        x = VarArray(size=4, dom=range(2))
+        a = Automaton(start="q0", final="q1", transitions=[("q0", 0, "q0"), ("q0", 1, "q1"), ("q1", 1, "q1")])
+        satisfy(Regular(scope=x, automaton=a))
     """
     scope = flatten(scope)
     checkType(scope, [Variable])
@@ -1247,6 +1355,9 @@ def AllDifferent(term, *others, excepting=None, matrix=False):
     :param excepting: the value(s) that must be ignored (None, most of the time)
     :param matrix: if True, the matrix version must be considered
     :return: a constraint AllDifferent
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(AllDifferent(x))
     """
     excepting = list(excepting) if isinstance(excepting, (tuple, set)) else [excepting] if isinstance(excepting, int) else excepting
     checkType(excepting, ([int], type(None)))
@@ -1275,6 +1386,9 @@ def AllDifferentList(term, *others, excepting=None):
     :param others: the other terms (if any) on which the constraint applies
     :param excepting: the tuple(s) that must be ignored (None, most of the time)
     :return: a constraint AllDifferentList
+    :example:
+        x = VarArray(size=[3, 2], dom=range(3))
+        satisfy(AllDifferentList(x))
     """
     if isinstance(term, types.GeneratorType):
         term = [v for v in term]
@@ -1296,6 +1410,9 @@ def AllEqual(term, *others, excepting=None):
     :param others: the other terms (if any) on which the constraint applies
     :param excepting: the value(s) that must be ignored (None, most of the time)
     :return: a constraint AllEqual
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(AllEqual(x))
     """
     excepting = list(excepting) if isinstance(excepting, (tuple, set)) else [excepting] if isinstance(excepting, int) else excepting
     checkType(excepting, ([int], type(None)))
@@ -1316,6 +1433,9 @@ def AllEqualList(term, *others, excepting=None):
     :param others: the other terms (if any) on which the constraint applies
     :param excepting: the tuple(s) that must be ignored (None, most of the time)
     :return: a constraint AllEqualList
+    :example:
+        x = VarArray(size=[3, 2], dom=range(3))
+        satisfy(AllEqualList(x))
     """
     if isinstance(term, types.GeneratorType):
         term = [v for v in term]
@@ -1361,6 +1481,9 @@ def Increasing(term, *others, strict=False, lengths=None):
     :param strict: if True, strict ordering must be considered
     :param lengths: the lengths (durations) that must separate the values
     :return: a constraint Increasing
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(Increasing(x, strict=True))
     """
     return _ordered(term, others, TypeOrderedOperator.INCREASING if not strict else TypeOrderedOperator.STRICTLY_INCREASING, lengths)
 
@@ -1374,6 +1497,9 @@ def Decreasing(term, *others, strict=False, lengths=None):
     :param strict: if True, strict ordering must be considered
     :param lengths: the lengths (durations) that must separate the values
     :return: a constraint Decreasing
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(Decreasing(x))
     """
     return _ordered(term, others, TypeOrderedOperator.DECREASING if not strict else TypeOrderedOperator.STRICTLY_DECREASING, lengths)
 
@@ -1409,6 +1535,9 @@ def LexIncreasing(term, *others, strict=False, matrix=False):
     :param strict: if True, strict ordering must be considered
     :param matrix: if True, the matrix version must be considered
     :return: a constraint Lexicographic
+    :example:
+        x = VarArray(size=[3, 2], dom=range(3))
+        satisfy(LexIncreasing(x))
     """
     return _lex(term, others, TypeOrderedOperator.INCREASING if not strict else TypeOrderedOperator.STRICTLY_INCREASING, matrix)
 
@@ -1422,6 +1551,9 @@ def LexDecreasing(term, *others, strict=False, matrix=False):
     :param strict: if True, strict ordering must be considered
     :param matrix: if True, the matrix version must be considered
     :return: a constraint Lexicographic
+    :example:
+        x = VarArray(size=[3, 2], dom=range(3))
+        satisfy(LexDecreasing(x))
     """
     return _lex(term, others, TypeOrderedOperator.DECREASING if not strict else TypeOrderedOperator.STRICTLY_DECREASING, matrix)
 
@@ -1434,6 +1566,9 @@ def Disjoint(term, *others):
     :param others: the other terms (if any) on which the constraint applies
 
     :return: a constraint Disjoint
+    :example:
+        x = VarArray(size=[2, 3], dom=range(6))
+        satisfy(Disjoint(x))
     """
     if isinstance(term, types.GeneratorType):
         term = [v for v in term]
@@ -1453,6 +1588,9 @@ def Precedence(within, *, values=None, covered=False):
     When None, all values in the scope of the first variable are considered
     :param covered: if True, all specified values must be assigned to the variables of the scope
     :return: a constraint Precedence
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(Precedence(x, values=[0, 1]))
     """
     assert len(within) > 2
     if values is None:
@@ -1489,6 +1627,9 @@ def Sum(term, *others, condition=None):
     :param others: the other terms (if any) on which the sum applies
     :param condition: a condition directly specified for the sum (typically, None)
     :return: a component/constraint Sum
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(Sum(x) == 6)
     """
 
     def _get_terms_coeffs(terms):
@@ -1579,6 +1720,9 @@ def Product(term, *others):
     :param term: the first term on which the product applies
     :param others: the other terms (if any) on which the product applies
     :return: a node, root of a tree expression
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(Product(x) == 0)
     """
 
     terms = flatten(term, others)
@@ -1601,6 +1745,9 @@ def Count(within, *within_complement, value=None, values=None, condition=None):
     :param values: the values to be counted
     :param condition: a condition directly specified for the count (typically, None)
     :return: a component/constraint Count
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(Count(x, value=0) == 1)
     """
     terms = flatten(within, within_complement)
     if len(terms) == 0:
@@ -1638,6 +1785,9 @@ def Exist(within, *within_complement, value=None, reified_by=None):
     :param value: the value to be found if not None (None, by default)
     :param reified_by: if present (not None) a 01 variable corresponding to the reification of the constraint
     :return: a constraint Count
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(Exist(x, value=0))
     """
     terms = flatten(within, within_complement)
     if len(terms) == 0:
@@ -1678,6 +1828,9 @@ def AnyHold(within, *within_complement):
     :param within: the first term on which the count applies
     :param within_complement: the other terms (if any) on which the count applies
     :return: a constraint Count
+    :example:
+        b = VarArray(size=3, dom={0, 1})
+        satisfy(AnyHold(b))
     """
     return Exist(within, within_complement, value=None)
 
@@ -1691,6 +1844,9 @@ def NotExist(within, *within_complement, value=None):
     :param within_complement: the other terms (if any) on which the count applies
     :param value: the value to be tested if not None (None, by default)
     :return: a constraint Count
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(NotExist(x, value=0))
     """
     terms = flatten(within, within_complement)
     res = Count(terms, value=value)
@@ -1707,6 +1863,9 @@ def NoneHold(within, *within_complement):
     :param within: the first term on which the count applies
     :param within_complement: the other terms (if any) on which the count applies
     :return: a constraint Count
+    :example:
+        b = VarArray(size=3, dom={0, 1})
+        satisfy(NoneHold(b))
     """
     return NotExist(within, within_complement, value=None)
 
@@ -1720,6 +1879,9 @@ def ExactlyOne(within, *within_complement, value=None):
     :param within_complement: the other terms (if any) on which the count applies
     :param value: the value to be found if not None (None, by default)
     :return: a constraint Count
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(ExactlyOne(x, value=0))
     """
     terms = flatten(within, within_complement)
     res = Count(terms, value=value)
@@ -1739,6 +1901,9 @@ def AtLeastOne(within, *within_complement, value=None):
     :param within_complement: the other terms (if any) on which the count applies
     :param value: the value to be found if not None (None, by default)
     :return: a constraint Count
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(AtLeastOne(x, value=0))
     """
     return Exist(within, within_complement, value=value)
 
@@ -1752,6 +1917,9 @@ def AtMostOne(within, *within_complement, value=None):
     :param within_complement: the other terms (if any) on which the count applies
     :param value: the value to be found if not None (None, by default)
     :return: a constraint Count
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(AtMostOne(x, value=0))
     """
     terms = flatten(within, within_complement)
     res = Count(terms, value=value)
@@ -1768,6 +1936,9 @@ def AllHold(within, *within_complement):
     :param within: the first term on which the count applies
     :param within_complement: the other terms (if any) on which the count applies
     :return: a constraint Count
+    :example:
+        b = VarArray(size=3, dom={0, 1})
+        satisfy(AllHold(b))
     """
     terms = flatten(within, within_complement)
     res = Count(terms)  # , value=value)
@@ -1784,6 +1955,10 @@ def Hamming(term, *others):
     :param term: the first term on which the constraint applies
     :param others: the other terms (if any) on which the constraint applies
     :return: a constraint Sum
+    :example:
+        x = VarArray(size=3, dom=range(3))
+        y = VarArray(size=3, dom=range(3))
+        satisfy(Hamming(x, y) == 2)
     """
     if isinstance(term, types.GeneratorType):
         term = [v for v in term]
@@ -1803,6 +1978,9 @@ def NValues(within, *within_complement, excepting=None, condition=None):
     :param excepting: the value(s) that must be ignored (None, most of the time)
     :param condition: a condition directly specified for the count (typically, None)
     :return: a component/constraint NValues
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(NValues(x) == 2)
     """
     terms = flatten(within, within_complement)
     if len(terms) == 0:
@@ -1834,6 +2012,9 @@ def NumberDistinctValues(within, *within_complement, excepting=None, condition=N
         :param excepting: the value(s) that must be ignored (None, most of the time)
         :param condition: a condition directly specified for the count (typically, None)
         :return: a component/constraint NValues
+        :example:
+            x = VarArray(size=4, dom=range(4))
+            satisfy(NumberDistinctValues(x) == 2)
         """
     return NValues(within, *within_complement, excepting=excepting, condition=condition)
 
@@ -1845,6 +2026,9 @@ def NotAllEqual(term, *others):
       :param term: the first term on which the constraint applies
       :param others: the other terms (if any) on which the constraint applies
       :return: a constraint NValues (equivalent to NotAllEqual)
+      :example:
+          x = VarArray(size=4, dom=range(4))
+          satisfy(NotAllEqual(x))
       """
     return NValues(term, others) > 1
 
@@ -1861,6 +2045,9 @@ def Cardinality(within, *within_complement, occurrences, closed=False):
     :param occurrences: a dictionary indicating the restriction (constant, range or variable) of occurrences per value
     :param closed: if True, variables must be assigned to values (keys of the dictionary)
     :return: a Cardinality constraint
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(Cardinality(x, occurrences={0: 1, 1: 1, 2: 1, 3: 1}))
     """
     terms = flatten(within, within_complement)
     if len(terms) == 0:
@@ -1917,6 +2104,9 @@ def Maximum(term, *others, condition=None):
     :param others: the other terms (if any) on which the maximum applies
     :param condition: a condition directly specified for the maximum (typically, None)
     :return: a component/constraint Maximum
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(Maximum(x) == 3)
     """
     terms = _extremum_terms(term, others)
     assert len(terms) > 0
@@ -1934,6 +2124,9 @@ def Minimum(term, *others, condition=None):
     :param others: the other terms (if any) on which the minimum applies
     :param condition: a condition directly specified for the minimum (typically, None)
     :return: a component/constraint Minimum
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(Minimum(x) == 0)
     """
     terms = _extremum_terms(term, others)
     assert len(terms) > 0
@@ -1952,6 +2145,9 @@ def MaximumArg(term, *others, rank=None, condition=None):
     :param rank: ranking condition on the index (ANY, FIRST or LAST); ANY if None
     :param condition: a condition directly specified for the maximum (typically, None)
     :return: a component/constraint MaximumArg
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(MaximumArg(x) == 0)
     """
     terms = _extremum_terms(term, others)
     checkType(rank, (type(None), TypeRank))
@@ -1968,6 +2164,9 @@ def MinimumArg(term, *others, rank=None, condition=None):
     :param rank: ranking condition on the index (ANY, FIRST or LAST); ANY if None
     :param condition: a condition directly specified for the minimum (typically, None)
     :return: a component/constraint MinimumArg
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(MinimumArg(x) == 0)
     """
     terms = _extremum_terms(term, others)
     checkType(rank, (type(None), TypeRank))
@@ -1984,6 +2183,10 @@ def Channel(list1, list2=None, *, start_index1=0, start_index2=0):
     :param start_index1: the number used for indexing the first variable in the first list (0, by default)
     :param start_index2: the number used for indexing the first variable in the second list (0, by default)
     :return: a constraint Channel
+    :example:
+        x = VarArray(size=3, dom=range(3))
+        y = VarArray(size=3, dom=range(3))
+        satisfy(Channel(x, y))
     """
     list1 = flatten(list1)
     checkType(list1, [Variable])
@@ -2027,6 +2230,9 @@ def NoOverlap(tasks=None, *, origins=None, lengths=None, zero_ignored=True):
     :param lengths: the lengths of the tasks
     :param zero_ignored: if True, the tasks with length 0 must be discarded
     :return: a constraint NoOverlap
+    :example:
+        s = VarArray(size=3, dom=range(10))
+        satisfy(NoOverlap(origins=s, lengths=[2, 3, 1]))
     """
     if tasks is not None:
         assert origins is None and lengths is None
@@ -2118,6 +2324,9 @@ def Cumulative(tasks=None, *, origins=None, lengths=None, ends=None, heights=Non
     :param heights: the heights (amounts of resource consumption) of the tasks
     :param condition: a condition directly specified for the Cumulative (typically, None)
     :return: a component/constraint Cumulative
+    :example:
+        s = VarArray(size=3, dom=range(10))
+        satisfy(Cumulative(origins=s, lengths=[2, 3, 1], heights=[1, 1, 2]) <= 2)
     """
     if tasks is not None:
         assert origins is None and lengths is None and ends is None and heights is None
@@ -2178,6 +2387,9 @@ def BinPacking(partition, *partition_complement, sizes, limits=None, loads=None,
     :param loads: the loads of bins (if limits is None)
     :param condition: a condition directly specified for the BinPacking (typically, None)
     :return: a component/constraint BinPacking
+    :example:
+        b = VarArray(size=4, dom=range(2))
+        satisfy(BinPacking(b, sizes=[3, 2, 2, 1]) <= 5)
     """
     terms = flatten(partition, partition_complement)
     assert len(terms) > 0, "A binPacking with an empty scope"
@@ -2216,6 +2428,9 @@ def Knapsack(selection, *selection_complement, weights, wlimit=None, wcondition=
     :param profits: the benefits associated with the items
     :param pcondition: a condition on the profits directly specified for the Knapsack (typically, None)
     :return: a component/constraint Knapsack
+    :example:
+        b = VarArray(size=4, dom={0, 1})
+        satisfy(Knapsack(b, weights=[3, 2, 2, 1], wlimit=5, profits=[4, 3, 2, 1]) >= 6)
     """
 
     terms = flatten(selection, selection_complement)
@@ -2243,6 +2458,9 @@ def Flow(term, *others, balance, arcs, weights=None, condition=None):
     :param weights: the weight (cost) of the arcs, given by an integer or a list of integers (None, by default)
     :param condition: a condition directly specified for the Flow (typically, None)
     :return: a component Flow
+    :example:
+        f = VarArray(size=3, dom=range(4))
+        satisfy(Flow(f, balance=[2, 0, -2], arcs=[(0, 1), (1, 2), (0, 2)], weights=[1, 2, 3]) <= 10)
     """
     terms = flatten(term, others)
     assert len(terms) > 0, "A Flow with an empty scope"
@@ -2274,6 +2492,9 @@ def Circuit(successors, *successors_complement, start_index=0, size=None, no_sel
     :param start_index: the number used for indexing the first variable/node in the list of terms
     :param size: the size of the circuit (a constant, a variable or None)
     :return: a constraint Circuit
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(Circuit(x))
     """
     successors = flatten(successors, successors_complement)
     checkType(successors, [Variable])
@@ -2300,6 +2521,9 @@ def Clause(variables, *variables_complement, phases=None):
         :param variables_complement: the other terms (if any) on which the constraint applies
         :param phases: the phase of the variables involved in the clause
         :return: a constraint Clause
+        :example:
+            b = VarArray(size=3, dom={0, 1})
+            satisfy(Clause(b, phases=[True, False, True]))
         """
     variables = flatten(variables, variables_complement)
     phases = [False] * len(variables) if phases is None else flatten(phases)
@@ -2320,6 +2544,9 @@ def Adhoc(form, note=None, **d):
     :param note: a comment
     :param d: a dictionary with all arguments of the adhoc constraint
     :return: a constraint Adhoc
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(Adhoc("myform", t=[0, 1, 2]))
     """
     return ECtr(ConstraintAdhoc(form, note, d))
 
@@ -2393,6 +2620,10 @@ def minimize(term):
 
     :param term: the term to be minimized
     :return: the objective to be minimized
+    :example:
+        x = VarArray(size=3, dom=range(10))
+        satisfy(AllDifferent(x))
+        minimize(Sum(x))
     """
     return _optimize(term, True)
 
@@ -2404,6 +2635,10 @@ def maximize(term):
 
     :param term: the term to be maximized
     :return: the objective to be maximized
+    :example:
+        x = VarArray(size=3, dom=range(10))
+        satisfy(AllDifferent(x))
+        maximize(Sum(x))
     """
     return _optimize(term, False)
 
@@ -2426,6 +2661,10 @@ def annotate(*, decision=None, output=None, varHeuristic=None, valHeuristic=None
     :param search: the annotation about search
     :param restarts: the annotation about restarts
     :return: a list of annotations
+    :example:
+        x = VarArray(size=3, dom=range(3))
+        satisfy(AllDifferent(x))
+        annotate(decision=x)
     """
     def add_annotation(obj, Ann):
         if obj:
@@ -2456,6 +2695,10 @@ def posted(i=None, j=None):
 
     :param i: the number/index of the posting operation (i.e., call to satisfy())
     :param j: the number (or slice) of the constraint with respect to the ith posting operation
+    :example:
+        x = VarArray(size=3, dom=range(3))
+        satisfy(AllDifferent(x))
+        print(posted())
     """
     t = []
     if i is None or i is ALL:  # all posted constraints are returned
@@ -2482,6 +2725,11 @@ def posted(i=None, j=None):
 def objective():
     """
     Returns the objective of the model, or None if no one has been defined by calling either the function minimize() or the function maximize()
+    :example:
+        x = VarArray(size=3, dom=range(3))
+        satisfy(AllDifferent(x))
+        minimize(Sum(x))
+        print(objective())
     """
     assert len(ObjEntities.items) <= 1
     return ObjEntities.items[0].constraint if len(ObjEntities.items) == 1 else None
@@ -2498,6 +2746,11 @@ def unpost(i=None, j=None):
     :param i: the index of the posting operation (call to satisfy) to be discarded (if j is None)
     :param j: the index (or slice) of the constraint(s) to be removed inside the group of constraints
               corresponding to the specified posting operation
+    :example:
+        x = VarArray(size=3, dom=range(3))
+        satisfy(AllDifferent(x))
+        satisfy(x[0] == 0)
+        unpost(1)
     """
     if i is None:
         i = -1
@@ -2518,6 +2771,11 @@ def value(model_variable, *, sol=-1):
 
     :param model_variable: a variable of the model
     :param sol: the index of a found solution
+    :example:
+        x = VarArray(size=3, dom=range(3))
+        satisfy(AllDifferent(x))
+        if solve() is SAT:
+            print(value(x[0]))
     """
     assert isinstance(model_variable, Variable) and len(model_variable.values) > 0
     return model_variable.values[sol]
@@ -2531,6 +2789,11 @@ def values(model_variables, *model_variables_complement, sol=-1):
     :param model_variables: the first term (typically, a list) containing variables on which the function applies
     :param model_variables_complement: the other terms (if any) on which the function applies
     :param sol: the order (index) of a found solution
+    :example:
+        x = VarArray(size=3, dom=range(3))
+        satisfy(AllDifferent(x))
+        if solve() is SAT:
+            print(values(x))
     """
     m = flatten(model_variables, model_variables_complement)
     if isinstance(m, Variable):

--- a/pycsp3/tools/curser.py
+++ b/pycsp3/tools/curser.py
@@ -1088,6 +1088,9 @@ def rows(m):
 
     :param m: a matrix (i.e. a two-dimensional list)
     :return: the matrix (possibly after converting its type)
+    :example:
+        x = VarArray(size=[3, 3], dom=range(3))
+        satisfy(AllDifferent(row) for row in rows(x))
     """
     assert is_matrix(m)
     mode = 0 if is_matrix(m, Variable) else 1 if is_matrix(m, int) else 2
@@ -1100,6 +1103,9 @@ def columns(m):
 
     :param m: a matrix (i.e. a two-dimensional list)
     :return: the transpose matrix
+    :example:
+        x = VarArray(size=[3, 3], dom=range(3))
+        satisfy(AllDifferent(col) for col in columns(x))
     """
     assert is_matrix(m)
     mode = 0 if is_matrix(m, Variable) else 1 if is_matrix(m, int) else 2
@@ -1113,6 +1119,9 @@ def ring(matrix, k=0):
     :param matrix: a matrix (i.e. a two-dimensional list)
     :param k: the index of the ring (from the outside towards the inside, starting at 0)
     :return: the list of variables forming the kth ring of the specified matrix
+    :example:
+        x = VarArray(size=[4, 4], dom=range(4))
+        satisfy(AllDifferent(ring(x, 0)))
     """
     assert is_matrix(matrix) and isinstance(k, int) and k < min(len(matrix), len(matrix[0])) // 2
     n, m = len(matrix), len(matrix[0])
@@ -1134,6 +1143,9 @@ def diagonal_down(m, i=-1, j=-1, check=True):
     :param j: index of column (possibly -1)
     :param check: true when the structure of the matrix must be controlled
     :return: the main downward diagonal (or another stipulated downward diagonal)
+    :example:
+        x = VarArray(size=[3, 3], dom=range(3))
+        satisfy(AllDifferent(diagonal_down(x)))
     """
     if check is True:
         assert is_square_matrix(m), "The specified first parameter must be a square matrix."
@@ -1152,6 +1164,9 @@ def diagonals_down(m, *, broken=False):
     :param m: a matrix (i.e. a two-dimensional list)
     :param broken: true when broken diagonals must be completed
     :return: the list of downward diagonals
+    :example:
+        x = VarArray(size=[3, 3], dom=range(3))
+        satisfy(AllDifferent(d) for d in diagonals_down(x))
     """
     assert is_square_matrix(m), "The specified first parameter must be a square matrix."
     mode = 0 if is_matrix(m, Variable) else 1 if is_matrix(m, int) else 2
@@ -1171,6 +1186,9 @@ def diagonal_up(m, i=-1, j=-1, check=True):
        :param j: index of column (possibly -1)
        :param check: true when the structure of the matrix must be controlled
        :return: the main upward diagonal (or another stipulated upward diagonal)
+       :example:
+           x = VarArray(size=[3, 3], dom=range(3))
+           satisfy(AllDifferent(diagonal_up(x)))
        """
     if check is True:
         assert is_square_matrix(m), "The specified first parameter must be a square matrix."
@@ -1189,6 +1207,9 @@ def diagonals_up(m, *, broken=False):
       :param m: a matrix (i.e. a two-dimensional list)
       :param broken: true when broken diagonals must be completed
       :return: the list of upward diagonals
+      :example:
+          x = VarArray(size=[3, 3], dom=range(3))
+          satisfy(AllDifferent(d) for d in diagonals_up(x))
       """
     assert is_square_matrix(m), "The specified first parameter must be a square matrix."
     mode = 0 if is_matrix(m, Variable) else 1 if is_matrix(m, int) else 2
@@ -1204,6 +1225,9 @@ def diagonals(m):
 
       :param m: a matrix (i.e. a two-dimensional list)
       :return: a list with the two main diagonals
+      :example:
+          x = VarArray(size=[3, 3], dom=range(3))
+          satisfy(AllDifferent(d) for d in diagonals(x))
       """
     assert is_square_matrix(m), "The specified first parameter must be a square matrix."
     mode = 0 if is_matrix(m, Variable) else 1 if is_matrix(m, int) else 2
@@ -1219,6 +1243,10 @@ def cp_array(*t):
 
     :param t: a list (of any dimension)
     :return: the same list, possibly converted into one of the two more specific types ListInt and ListVar
+    :example:
+        x = VarArray(size=3, dom=range(3))
+        t = cp_array([2, 0, 1])
+        satisfy(t[x[0]] == 1)
     """
     if len(t) == 1:
         t = t[0]

--- a/pycsp3/tools/utilities.py
+++ b/pycsp3/tools/utilities.py
@@ -84,10 +84,21 @@ class _Star(float):
 
 
 ANY = _Star("Inf")  #: used to represent * in short tables
-""" Constant used to represent * in starred tables """
+""" Constant used to represent * in starred tables
+
+:example:
+    x = VarArray(size=3, dom=range(3))
+    satisfy((x[0], x[1], x[2]) in {(0, ANY, 1), (1, 1, ANY)})
+"""
 
 ALL = "all"
-""" Constant used to indicate, for example, that all solutions must be sought """
+""" Constant used to indicate, for example, that all solutions must be sought
+
+:example:
+    x = VarArray(size=3, dom=range(3))
+    satisfy(AllDifferent(x))
+    print(ALL)
+"""
 
 
 def combinations(n, size):
@@ -97,6 +108,9 @@ def combinations(n, size):
     :param n: an iterable object, or an integer n standing for range(n)
     :param size: the size of each combination
     :return: an iterator over all combinations of the specified size
+    :example:
+        x = VarArray(size=4, dom=range(4))
+        satisfy(x[i] != x[j] for i, j in combinations(4, 2))
     """
     return itertools.combinations(n if not isinstance(n, int) else range(n), size)
 
@@ -109,6 +123,8 @@ def different_values(*args):
     """
     Returns True if all specified integers are different
     :return: True if all specified integers are different
+    :example:
+        print(different_values(1, 2, 3))
     """
     assert all(isinstance(arg, int) for arg in args)
     return all(a != b for (a, b) in combinations(args, 2))
@@ -120,6 +136,9 @@ def flatten(*args, keep_none=False, keep_tuples=False, call_cp_array=True):
     Typically, this is a list (of possibly any dimension).
 
     :param keep_none: if True, None values are not discarded
+    :example:
+        x = VarArray(size=[2, 2], dom=range(4))
+        satisfy(AllDifferent(flatten(x)))
     """
     # if not hasattr(flatten, "cache"):  # cannot work (changing to TupleInt and TupleVar instead of ListInt and ListVar while guaranteeing the lifetime? how?)
     #     flatten.cache = {}
@@ -218,6 +237,8 @@ def alphabet_positions(s):
     Returns a tuple with the indexes of the letters (with respect to the 26 letters of the Latin alphabet) of the specified string.
 
     :param s: a string
+    :example:
+        print(alphabet_positions("abc"))
     """
 
     if isinstance(s, (list, tuple, set, frozenset, types.GeneratorType)):
@@ -230,6 +251,9 @@ def all_primes(limit):
     Returns a list with all prime numbers that are strictly less than the specified limit.
 
     :param limit: an integer
+    :example:
+        x = VarArray(size=3, dom=range(20))
+        satisfy(belong(x[0], set(all_primes(20))))
     """
     sieve = [True] * limit
     for i in range(3, int(limit ** 0.5) + 1, 2):
@@ -251,6 +275,8 @@ def value_in_base(decimal_value, length, base):
 def integer_scaling(values):
     """
     Returns a list with all specified values after possibly converting them (when decimal) into integers by means of automatic scaling
+    :example:
+        print(integer_scaling([0.5, 1.25]))
     """
     values = list(values) if isinstance(values, types.GeneratorType) else values
     values = [str(v) for v in values]
@@ -274,6 +300,8 @@ def number_of_values_for_sum_ge(tab, limit, reverse=False):
     :param limit: the limit to be reached
     :param reverse: if True, values are summed from the end of the list (i.e., the greatest ones first)
     :return: the minimum number of values whose sum is greater than or equal to the limit, or -1 if the limit cannot be reached
+    :example:
+        print(number_of_values_for_sum_ge([1, 2, 3, 4], 5))
     """
     assert isinstance(tab, list) and all(tab[i] <= tab[i + 1] for i in range(len(tab) - 1))
     csum = 0
@@ -299,6 +327,8 @@ def number_of_values_for_sum_gt(tab, limit, reverse=False):
     :param limit: the limit to be exceeded
     :param reverse: if True, values are summed from the end of the list (i.e., the greatest ones first)
     :return: the minimum number of values whose sum is greater than the limit, or -1 if the limit cannot be exceeded
+    :example:
+        print(number_of_values_for_sum_gt([1, 2, 3, 4], 5))
     """
     return number_of_values_for_sum_ge(tab, limit + 1, reverse)
 
@@ -311,6 +341,8 @@ def number_max_of_values_for_sum_le(tab, limit, reverse=False):
     :param limit: the limit that must not be exceeded
     :param reverse: if True, values are summed from the end of the list (i.e., the greatest ones first)
     :return: the maximum number of values whose sum is less than or equal to the limit
+    :example:
+        print(number_max_of_values_for_sum_le([1, 2, 3, 4], 5))
     """
     nb = number_of_values_for_sum_gt(tab, limit, reverse)
     return len(tab) if nb == -1 else nb - 1
@@ -324,6 +356,8 @@ def number_max_of_values_for_sum_lt(tab, limit, reverse=False):
     :param limit: the limit that must be stayed below
     :param reverse: if True, values are summed from the end of the list (i.e., the greatest ones first)
     :return: the maximum number of values whose sum is strictly less than the limit
+    :example:
+        print(number_max_of_values_for_sum_lt([1, 2, 3, 4], 5))
     """
     nb = number_of_values_for_sum_ge(tab, limit, reverse)
     return len(tab) if nb == -1 else nb - 1
@@ -338,6 +372,10 @@ def decrement(t):
 
     :param t: an integer, or a (possibly nested) list of integers or of tuples of integers
     :return: the specified object, with every integer decremented by 1
+    :example:
+        data = decrement([[1, 2], [3, 4]])
+        x = VarArray(size=2, dom=range(4))
+        satisfy(x[0] == data[0][0])
     """
     if isinstance(t, int):
         return t - 1
@@ -452,6 +490,10 @@ def build_table(domains, predicate):
     :param domains: the list of domains, one per column of the table
     :param predicate: a Boolean function taking as many arguments as there are domains
     :return: the list of tuples satisfying the predicate
+    :example:
+        x = VarArray(size=2, dom=range(4))
+        T = build_table([range(4), range(4)], lambda a, b: a + b == 3)
+        satisfy((x[0], x[1]) in T)
     """
     T = []
     for t in product(*domains):
@@ -507,6 +549,8 @@ def warning(message, type_message=None):
 
     :param message: the message to be displayed
     :param type_message: when specified, the kind of warning, so that similar cases are only displayed one time (None, by default)
+    :example:
+        warning("the data file looks empty")
     """
     if options.dont_display_warnings:
         return


### PR DESCRIPTION
Every function of the public interface now carries a reST `:example:` field with a minimal, self-contained snippet — 127 in total.

> **Base branch.** This is stacked on `fix/api-docstrings` (#59), because several of these examples document functions whose docstring is only added there. Merge #59 first; this PR can then be retargeted to `master`.

### The examples were run, not written from memory

Every one of them was executed against the library before being committed. Each runs in its own process, in console mode (as in a notebook), so no model state leaks from one example to the next. The ones calling `solve()` really invoke the solver.

Writing them surfaced a handful of API details worth recording:

- `Regular` is keyword-only (`Regular(scope=..., automaton=...)`)
- `condition=` expects a pair, while `lt`/`le`/`ge`/`gt`/`eq`/`ne`/`complement` build a `Condition` object, accepted by `wcondition=` and as a `Match` case key
- `ANY` (the starred-table wildcard) is not `TypeRank.ANY`
- `Flow` needs a condition, given either as a pair or applied outside the call

### It also surfaced a real bug: `Not()` never worked

`manage_global_indirection()` always returns a list — a comment on its `return` even says a tuple breaks other callers. `Not()` applied the unary `~` to it directly:

```python
res = manage_global_indirection(arg)
return ~res  # TODO to be checked
```

so every call raised `TypeError: bad operand type for unary ~: 'list'`, including the form advertised in its own docstring, `Not(AllDifferent(x))`.

`Not()` was the only one of the five meta-constraints doing that indirection itself; `And()`, `Or()`, `Xor()` and `Iff()` delegate to `conjunction()`, `disjunction()`, `xor()` and `iff()`, which handle it internally. Negating the single element the list holds is enough:

```python
return ~res[0] if len(res) == 1 else ~conjunction(*res)
```

Checked on the **number of solutions**, not only on the absence of a crash. With `x` an array of 4 variables over `range(4)`: `AllDifferent(x)` has 24 solutions and `Not(AllDifferent(x))` has 232, i.e. `4**4 - 24`. With `x[0] == x[1]` (4) and `Not(x[0] == x[1])` (12), the counts are over the 2 variables the solver keeps, the other two appearing in no constraint: `4 + 12 = 4**2`. The negation is the exact complement in both cases.

### Scope

Apart from that one line in `Not()`, only docstrings are touched: stripping every docstring from the other modified files yields exactly the same code as before.
