### PR TITLE
Handle generators in the functions min() and max()

### DIFF
--- a/pycsp3/functions.py
+++ b/pycsp3/functions.py
@@ -1042,7 +1042,7 @@ def min(*args):
         x = VarArray(size=4, dom=range(4))
         satisfy(min(x[0], x[1]) == 0)
     """
-    if len(args) == 1 and isinstance(args[0], (tuple, list, set, frozenset)):
+    if len(args) == 1 and isinstance(args[0], (tuple, list, set, frozenset, types.GeneratorType)):
         args = [v for v in args[0]]
     return args[0] if len(args) == 1 and isinstance(args[0], (int, str, Variable, Node)) else Node.build(TypeNode.MIN, *args) if len(args) > 1 and any(
         isinstance(a, (Node, Variable)) for a in args) else minPython(*args)
@@ -1059,7 +1059,7 @@ def max(*args):
         x = VarArray(size=4, dom=range(4))
         satisfy(max(x[0], x[1]) == 3)
     """
-    if len(args) == 1 and isinstance(args[0], (tuple, list, set, frozenset)):
+    if len(args) == 1 and isinstance(args[0], (tuple, list, set, frozenset, types.GeneratorType)):
         args = [v for v in args[0]]
     return args[0] if len(args) == 1 and isinstance(args[0], (int, str, Variable, Node)) else Node.build(TypeNode.MAX, *args) if len(args) > 1 and any(
         isinstance(a, (Node, Variable)) for a in args) else maxPython(*args)


### PR DESCRIPTION
## Problem

`min()` and `max()` do not expand a generator, and so, fall back to the Python builtin. Since the
comparison operators are overloaded for variables and nodes (they build expressions, which are always
truthy), **no error is raised**: an arbitrary element of the generator is silently returned.

```python
from pycsp3 import *

x = VarArray(size=3, dom=range(5))

min(x[i] for i in range(3))    # -> x[2]                    expected: min(x[0],x[1],x[2])
max(x[i] for i in range(3))    # -> x[2]                    expected: max(x[0],x[1],x[2])

min([x[i] for i in range(3)])  # -> min(x[0],x[1],x[2])     lists are correctly handled
```

Both `min` and `max` return `x[2]` here, which is the signature of the builtin being applied to
objects whose `<` and `>` are overloaded: every comparison evaluates to a truthy node, so the builtin
just keeps the last element.

This is silent: the model compiles, the generated instance is valid XCSP3, and it simply does not
state the intended constraint. I ran into it while translating the MiniZinc model `code-generator`
(Unison) of the 2019 challenge, where minima and maxima over generated terms are frequent.

## Cause

`min()` and `max()` are the only two functions of `pycsp3/functions.py` whose test for expanding a
single argument omits `types.GeneratorType`:

| function | line | test |
|---|---|---|
| `min` | 1045 | `isinstance(args[0], (tuple, list, set, frozenset))` |
| `max` | 1062 | `isinstance(args[0], (tuple, list, set, frozenset))` |
| `xor` | 1079 | `isinstance(args[0], (tuple, list, set, frozenset, types.GeneratorType))` |
| `iff` | 1095 | `isinstance(args[0], (tuple, list, set, frozenset, types.GeneratorType))` |
| `conjunction` | 1288 | `isinstance(args[0], (tuple, list, set, frozenset, types.GeneratorType))` |
| `disjunction` | 1329 | `isinstance(args[0], (tuple, list, set, frozenset, types.GeneratorType))` |

This is the same family of problems as the two recent commits dd58c74 (*Simplification in functions
min() and max()*) and 8e1f1bd (*functions min() and max() more robust*), which fixed the case of a
single argument being a `Node` and then a `Variable`. Before 8e1f1bd, `min([x[0] + x[1]])` returned
`x[1]`; with the present commit, `min(x[i] for i in range(3))` no longer returns `x[2]`.

## Proposed fix

Add `types.GeneratorType` to the two tests, so that `min` and `max` behave like their neighbours.

## Checks

| call | before | after |
|---|---|---|
| `min(x[i] for i in range(3))` | `x[2]` | `min(x[0],x[1],x[2])` |
| `max(x[i] for i in range(3))` | `x[2]` | `max(x[0],x[1],x[2])` |
| `min(x[i] for i in range(1))` | `x[0]` | `x[0]` |
| `min([x[0], x[1]])` | `min(x[0],x[1])` | `min(x[0],x[1])` |
| `min([x[0] + x[1]])` | `add(x[0],x[1])` | `add(x[0],x[1])` |
| `min([x[0], 3])` | `min(x[0],3)` | `min(x[0],3)` |
| `min([1, 2, 3])` | `1` | `1` |
| `min(i for i in range(3))` | `0` | `0` |
| `max(v for v in [4, 1, 7])` | `7` | `7` |

The behaviour is thus unchanged for lists, tuples, sets and plain integers, and generators of
integers keep going to the Python builtin. A large model of mine (~850 lines, 1650 variables,
2 MB of generated XCSP3) produces a byte-identical instance before and after the fix.

## Not addressed here

`min([Sum(x)])` (a single `PartialConstraint`) still raises an assertion error, since the fall back
to the builtin iterates over it. Handling it would mean replacing partial constraints by auxiliary
variables, as `abs()` does; that is a design decision, so I left it out of this PR.
