### PR TITLE
Four problems met while translating MiniZinc models

### DIFF
--- a/pycsp3/classes/main/annotations.py
+++ b/pycsp3/classes/main/annotations.py
@@ -87,7 +87,8 @@ class AnnotationVarHeuristic(AnnotationHeuristic):
     def __init__(self, h):
         super().__init__(TypeAnn.VAR_HEURISTIC)
         checkType(h, VarHeuristic)
-        self.attributes.append((TypeAnnArg.LC, h.lc))
+        if h.lc is not None:  # otherwise, the attribute would be written as lc="None"
+            self.attributes.append((TypeAnnArg.LC, h.lc))
         if h.staticParts:
             self.arg(TypeAnnArg.STATIC, h.staticParts[0])
         self.add_arguments(h.randomPart, h.minPart, h.maxPart)

--- a/pycsp3/functions.py
+++ b/pycsp3/functions.py
@@ -751,9 +751,10 @@ def Slide(*args, expression=None, circular=None, offset=None, collect=None):
 def _01_to_node(arg):
     if isinstance(arg, Variable):
         assert arg.dom.is_binary()
-        b = arg.negation
-        arg.negation = False
-        return Node.build(TypeNode.EQ, arg, 0 if b else 1)  # transformed into a basic logical equation
+        # the declared variable is used: arg may be a variant (as built by ~x), which is a distinct object,
+        # unknown of VarEntities.varToEVarArray (and modifying it in place would corrupt the expressions using it)
+        x = Variable.name2obj.get(arg.id, arg)
+        return Node.build(TypeNode.EQ, x, 0 if arg.negation else 1)  # transformed into a basic logical equation
     if isinstance(arg, PartialConstraint):
         assert isinstance(arg.constraint, ConstraintElement)  # TODO to be extended (other cases should be possible)
         assert all(isinstance(t, Variable) and t.dom.is_binary() for t in arg.constraint.arguments[TypeCtrArg.LIST].content)  # TODO to be extended
@@ -1847,7 +1848,7 @@ def Exist(within, *within_complement, value=None, reified_by=None):
     if reified_by is not None:
         assert isinstance(reified_by, Variable) and reified_by.dom.is_binary()
         if reified_by.negation:
-            reified_by.negation = False
+            reified_by = Variable.name2obj.get(reified_by.id, reified_by)  # the declared variable (see _01_to_node)
             aux = auxiliary().new_var(0, 1)
             satisfy(aux != reified_by)
             reified_by = aux

--- a/pycsp3/tools/curser.py
+++ b/pycsp3/tools/curser.py
@@ -585,15 +585,11 @@ class OpOverrider:
             self = gi
         if isinstance(self, VariableInteger):
             return Variable.__invert__(self)
-        if isinstance(self, Node):  # we simplify when possible
+        if isinstance(self, Node):  # we simplify when possible (while building new nodes, as the node may be shared)
             if ~self.type is not None:
-                self.type = ~self.type
-                return self
+                return Node(~self.type, self.cnt)
             if self.type in (TypeNode.AND, TypeNode.OR) and all(~son.type is not None for son in self.cnt):
-                for son in self.cnt:
-                    son.type = ~son.type
-                self.type = TypeNode.OR if self.type == TypeNode.AND else TypeNode.AND
-                return self
+                return Node(TypeNode.OR if self.type == TypeNode.AND else TypeNode.AND, [Node(~son.type, son.cnt) for son in self.cnt])
         return Node.build(TypeNode.NOT, self)
 
     def __xor__(self, other):

--- a/pycsp3/tools/inspector.py
+++ b/pycsp3/tools/inspector.py
@@ -24,7 +24,12 @@ def _global_value_of(variable):
     if len(frames) == 0:
         return None
     globs = frames[0].frame.f_globals
-    return str(globs[variable]) if variable in globs.keys() else None
+    if variable not in globs.keys():
+        return None
+    value = globs[variable]
+    # functions, classes and modules are discarded: their string representation involves a memory address,
+    # and so, the generated instance would not be reproducible (besides, they are not data of the model)
+    return None if callable(value) or inspect.ismodule(value) else str(value)
 
 
 def is_comment_line(line):

--- a/pycsp3/tools/xcsp.py
+++ b/pycsp3/tools/xcsp.py
@@ -239,9 +239,12 @@ def _annotation(entity, *, possible_simplified_form=False):
         return None
     elt = _element(c.name, entity, attributes=c.attributes)
     arguments = [arg for arg in c.arguments.values() if arg.content is not None]  # we keep only valid (non null) arguments
-    if c.name == TypeAnn.VAL_HEURISTIC:
-        assert len(arguments) == 1 and arguments[0].name == TypeAnnArg.STATICS, "for the moment"
-        _argument(elt, arguments[0], arguments[0].name, arguments[0].content)
+    if c.name in (TypeAnn.VAR_HEURISTIC, TypeAnn.VAL_HEURISTIC):
+        if len(arguments) == 1 and arguments[0].name == TypeAnnArg.STATIC:
+            _text(elt, arguments[0].content)  # simplified form, when only a static order of the variables is given
+        else:
+            for arg in arguments:  # the forms static, random, min and max are all written as sub-elements
+                _argument(elt, arg, arg.name, arg.content)
     else:
         assert len(arguments) == 1, "for the moment"
         _text(elt, arguments[0].content)


### PR DESCRIPTION
Four independent problems, met while translating in pycsp3 the MiniZinc model `code-generator`
(Unison) of the 2019 challenge, and the model `roomsgcc` of the 2026 challenge. All of them are
reproduced on master (6f6f33c), one commit per problem.

Each generated instance has been compared with the one obtained on master: the translated model
(850 lines, 1650 variables, 470 KB of XCSP3) gives a byte-identical instance.

---

## 1. The negation `~` was modifying the node (b906816)

The negation of a node was performed in place: `~e` changed the type of the node `e` (and of its sons
when the root is `and` or `or`) and returned that very same object. Any other constraint sharing the
node was then silently changed too.

```python
x = VarArray(size=2, dom=range(5))
e = conjunction(x[0] == 1, x[1] == 2)
satisfy(~e, e)
```

| | before | after |
|---|---|---|
| value of `e` after the call to `~` | `or(ne(x[0],1),ne(x[1],2))` | `and(eq(x[0],1),eq(x[1],2))` |
| constraints in the instance | **1** (both arguments having become the same object) | 2 |

This is silent and can make a model wrong: while translating Unison, expressions are built from data
and shared between constraints (a subexpression is used by a nogood, by a condition of `across`, by a
`before`...). Negating a nogood was turning equalities into disequalities inside the other
constraints. `Node.logical_inversion()` already builds a new node; the same is now done in
`OpOverrider.__invert__()`.

## 2. `KeyError` in the compactor with 0/1 variables used as constraints (e5129d7)

```python
x = VarArray(size=4, dom={0, 1})
satisfy(
    [~(x[i] == 1) for i in range(3)]
)
```

```
File "pycsp3/tools/compactor.py", line 104, in update
  if len(part) == 0 or VarEntities.varToEVarArray[z].id == VarEntities.varToEVarArray[part[-1]].id:
KeyError: x[1]
```

`~x` builds a variant of `x`: a distinct object, with the same id, unknown of
`VarEntities.varToEVarArray`. When such a 0/1 variable is used as a constraint, `_01_to_node()` was
setting the field `negation` of the variant to `False` (modifying it in place) and putting that very
object in the built node; the compactor was then failing on it when building an instantiation (with
only two such constraints, no instantiation is built and the compilation succeeds).

The declared variable, given by `Variable.name2obj`, is now used. The three constraints above are
compiled into `<instantiation> <list> x[0..2] </list> <values> 0x3 </values> </instantiation>`.
The same pattern, in `Exist()` when `reified_by` is a negated variable, is fixed too (same output).

Two of the five official instances of `code-generator` could not be compiled because of this.

## 3. Annotations: attribute `lc="None"`, and the forms `min`/`max` not written (59cd005)

```python
annotate(varHeuristic=VarHeuristic().static(x))   ->  <varHeuristic lc="None"> x[] </varHeuristic>
annotate(valHeuristic=ValHeuristic().min(x, h_type="VALUE"))
    File "pycsp3/tools/xcsp.py", line 243, in _annotation
      assert len(arguments) == 1 and arguments[0].name == TypeAnnArg.STATICS, "for the moment"
    AssertionError: for the moment
```

The attribute `lc` is now written only when it is given, and the forms `static`, `random`, `min` and
`max` are all written, for the two kinds of heuristics:

```xml
<varHeuristic lc="2"> x[] </varHeuristic>
<valHeuristic> <min type="VALUE"> x[] </min> </valHeuristic>
<varHeuristic> <min type="DOM"> x[] </min> </varHeuristic>
<valHeuristic> <static order="2 1 0"> x[] </static> <min type="VALUE"> x[] </min> </valHeuristic>
```

The simplified form `<varHeuristic> x[] </varHeuristic>` is kept when only a static order of the
variables is given. ACE accepts the four files above. This is what is needed for translating
`indomain_min` of MiniZinc, which had to be worked around by a static order of the values.

## 4. Substitution in the comments: instances not reproducible (df71829)

In the comment preceding a declaration, a word between single quotes is replaced by the value of the
global variable of the same name. Convenient for data, but no filtering was performed, and so the
~200 functions and classes imported by `from pycsp3 import *` were candidates too:

```python
# b[i] is the ith value ('lt' is a keyword of XCSP3)
b = VarArray(size=2, dom=range(3))
```
```xml
<array id="b" note="b[i] is the ith value (&lt;function lt at 0x75d23e948fe0&gt; is a keyword of XCSP3)" .../>
```

Besides the corrupted comment, **the generated instance is not reproducible**: two executions of the
same model on the same data give two different files, since the memory address changes. This is how
the problem was noticed: two instances of 470 KB differing only by this. Functions, classes and
modules are now discarded; the substitution of data is unchanged (`'nRooms'` still gives `7`).

---

## Two other problems, in the solver (nothing to do here)

For the record, two problems met with ACE 2.6 during the same work (assumed to be fixed in the solver
by now):

- `or(..., in(x, set(...)))` cannot be loaded when the set involves a value outside the domain of `x`
  (`Logic$LogicTree.buildTreeArgs`); e.g. `or(eq(y,0),in(r,set(1,9)))` with `r` in `0..5`. Filtering
  out the values outside the domain, when building the expression, is a workaround.
- a 2-dimensional `noOverlap` whose two boxes have a length equal to 0 in the same dimension and the
  same origin in that dimension is declared unsatisfiable, whereas such boxes must be ignored
  (`zeroIgnored`). On an instance of the translated Unison model, ACE was answering `s UNSATISFIABLE`
  after a complete exploration, while Choco was finding the optimum.
